### PR TITLE
Fix not searching after pressing enter

### DIFF
--- a/src/tableUtils.tsx
+++ b/src/tableUtils.tsx
@@ -14,7 +14,7 @@ export function tableColumnTextFilterConfig<T>(): ColumnType<T> {
           placeholder={'Search'}
           value={selectedKeys[0]}
           onChange={(e) => setSelectedKeys(e.target.value ? [e.target.value] : [])}
-          onPressEnter={()=>confirm}
+          onPressEnter={()=>confirm()}
           style={{width: 188, marginBottom: 8, display: 'block'}}
         />
         <Button


### PR DESCRIPTION
After typing the search string and pressing enter, nothing happens, because the `confirm` function isn't being called. This PR fixes that.